### PR TITLE
Hotfix/imagem quebrada cor errada

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         }
 
         header {
-            background-color: red;
+            background-color: #2980b9;
             color: #fff;
             padding: 10px;
             text-align: center;
@@ -62,7 +62,7 @@
 
 
         footer {
-            background-color: red;
+            background-color: #2980b9;
             color: #fff;
             text-align: center;
             padding: 30px;


### PR DESCRIPTION
Imagens estavam com o nome errado, foi concertado.
Cor do header e do footer em vermelho, trocado para azul